### PR TITLE
fix indent style

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,4 @@
+/* eslint indent: [2, 4] */
 module.exports = function karmaExports(config) {
     "use strict";
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
         "env": {
             "qunit": true,
             "node": true
+        },
+        "rules": {
+            "indent": [2,"tab", {"SwitchCase": 1}]
         }
     }
 }

--- a/tests_config.js
+++ b/tests_config.js
@@ -1,13 +1,13 @@
 (function (root, factory) {
 	'use strict';
 
-    if (typeof module === 'object' && module.exports) {
-        // Node. Does not work with strict CommonJS, but only CommonJS-like
+	if (typeof module === 'object' && module.exports) {
+		// Node. Does not work with strict CommonJS, but only CommonJS-like
 		// environments that support module.exports, like Node.
-        factory(require('./x2js'), require('qunit-cli'));
-    } else {
-        // Browser globals (root is window)
-        factory(root.X2JS, root.QUnit);
+		factory(require('./x2js'), require('qunit-cli'));
+	} else {
+		// Browser globals (root is window)
+		factory(root.X2JS, root.QUnit);
 	}
 })(this, function (X2JS, QUnit) {
 	'use strict';

--- a/tests_funky.js
+++ b/tests_funky.js
@@ -1,13 +1,13 @@
 (function (root, factory) {
 	'use strict';
 
-    if (typeof module === 'object' && module.exports) {
-        // Node. Does not work with strict CommonJS, but only CommonJS-like
+	if (typeof module === 'object' && module.exports) {
+		// Node. Does not work with strict CommonJS, but only CommonJS-like
 		// environments that support module.exports, like Node.
-        factory(require('./x2js'), require('qunit-cli'));
-    } else {
-        // Browser globals (root is window)
-        factory(root.X2JS, root.QUnit);
+		factory(require('./x2js'), require('qunit-cli'));
+	} else {
+		// Browser globals (root is window)
+		factory(root.X2JS, root.QUnit);
 	}
 })(this, function (X2JS, QUnit) {
 	'use strict';

--- a/tests_js2xml.js
+++ b/tests_js2xml.js
@@ -1,13 +1,13 @@
 (function (root, factory) {
 	'use strict';
 
-    if (typeof module === 'object' && module.exports) {
-        // Node. Does not work with strict CommonJS, but only CommonJS-like
+	if (typeof module === 'object' && module.exports) {
+		// Node. Does not work with strict CommonJS, but only CommonJS-like
 		// environments that support module.exports, like Node.
-        factory(require('./x2js'), require('qunit-cli'));
-    } else {
-        // Browser globals (root is window)
-        factory(root.X2JS, root.QUnit);
+		factory(require('./x2js'), require('qunit-cli'));
+	} else {
+		// Browser globals (root is window)
+		factory(root.X2JS, root.QUnit);
 	}
 })(this, function (X2JS, QUnit) {
 	'use strict';

--- a/tests_smoke.js
+++ b/tests_smoke.js
@@ -1,13 +1,13 @@
 (function (root, factory) {
 	'use strict';
 
-    if (typeof module === 'object' && module.exports) {
-        // Node. Does not work with strict CommonJS, but only CommonJS-like
+	if (typeof module === 'object' && module.exports) {
+		// Node. Does not work with strict CommonJS, but only CommonJS-like
 		// environments that support module.exports, like Node.
-        factory(require('./x2js'), require('qunit-cli'));
-    } else {
-        // Browser globals (root is window)
-        factory(root.X2JS, root.QUnit);
+		factory(require('./x2js'), require('qunit-cli'));
+	} else {
+		// Browser globals (root is window)
+		factory(root.X2JS, root.QUnit);
 	}
 })(this, function (X2JS, QUnit) {
 	'use strict';

--- a/tests_xml2js.js
+++ b/tests_xml2js.js
@@ -1,13 +1,13 @@
 (function (root, factory) {
 	'use strict';
 
-    if (typeof module === 'object' && module.exports) {
-        // Node. Does not work with strict CommonJS, but only CommonJS-like
+	if (typeof module === 'object' && module.exports) {
+		// Node. Does not work with strict CommonJS, but only CommonJS-like
 		// environments that support module.exports, like Node.
-        factory(require('./x2js'), require('qunit-cli'));
-    } else {
-        // Browser globals (root is window)
-        factory(root.X2JS, root.QUnit);
+		factory(require('./x2js'), require('qunit-cli'));
+	} else {
+		// Browser globals (root is window)
+		factory(root.X2JS, root.QUnit);
 	}
 })(this, function (X2JS, QUnit) {
 	'use strict';

--- a/x2js.js
+++ b/x2js.js
@@ -32,22 +32,22 @@
 	"use strict";
 
 	/* global define */
-    if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define([], factory);
-    } else if (typeof module === 'object' && module.exports) {
-        // Node. Does not work with strict CommonJS, but only CommonJS-like
+	if (typeof define === 'function' && define.amd) {
+		// AMD. Register as an anonymous module.
+		define([], factory);
+	} else if (typeof module === 'object' && module.exports) {
+		// Node. Does not work with strict CommonJS, but only CommonJS-like
 		// environments that support module.exports, like Node.
-        module.exports = factory(require("xmldom").DOMParser);
-    } else {
-        // Browser globals (root is window)
-        root.X2JS = factory();
+		module.exports = factory(require("xmldom").DOMParser);
+	} else {
+		// Browser globals (root is window)
+		root.X2JS = factory();
 	}
 })(this, function (CustomDOMParser) {
 	"use strict";
 
-    // We return a constructor that can be used to make X2JS instances.
-    return function X2JS(config) {
+	// We return a constructor that can be used to make X2JS instances.
+	return function X2JS(config) {
 		var VERSION = "3.1.1";
 
 		config = config || {};
@@ -401,7 +401,7 @@
 				}
 			}
 			delete result.__cnt;
-			
+
 			if (!config.keepCData && (!result.hasOwnProperty('__text') && result.hasOwnProperty('__cdata'))) {
 				return (result.__cdata ? result.__cdata : '');
 			}


### PR DESCRIPTION
In JS codes, 4 spaces indent and tab indent were mixed.
In github, tab is converted to 8 spaces.
So codes are not easy to understand the nest structure.

I added eslint rule `indent` to `package.json` and fixed those eslint warnings.