### PR TITLE
Add some optional capabilities (JS->XML filter, converter, dates)

### DIFF
--- a/tests_js2xml.js
+++ b/tests_js2xml.js
@@ -333,4 +333,91 @@
 		// Implementation does not guarantee formatting so the test is somewhat fragile.
 		assert.strictEqual(xml, expected);
 	});
+
+	QUnit.test('Filter out', function (assert) {
+		var js = {
+			'document': {
+				'elementV': [
+					{ 'x': 't' },
+					{ 'password': 'n' }
+				],
+				'password': 'n'
+			}
+		};
+		var x = new X2JS({
+			'jsAttributeFilter': function (name, value) {
+				return name === 'password';
+			}
+		});
+		var xml = x.js2xml(js);
+
+		var expected = '<document>' +
+			'<elementV><x>t</x></elementV>' +
+			'<elementV></elementV>' +
+			'</document>';
+
+		// Implementation does not guarantee formatting so the test is somewhat fragile.
+		assert.strictEqual(xml, expected);
+	});
+
+	QUnit.test('Attribute converter', function (assert) {
+		var js = {
+			'document': {
+				'elementV': [
+					{ 'x': 't' },
+					{ 'password': 'n' }
+				],
+				'password': 'n'
+			}
+		};
+		var x = new X2JS({
+			'jsAttributeConverter': function (name, value) {
+				return name === 'password' ? '***' : value;
+			}
+		});
+		var xml = x.js2xml(js);
+
+		var expected = '<document>' +
+			'<elementV><x>t</x></elementV>' +
+			'<elementV><password>***</password></elementV>' +
+			'<password>***</password>' +
+			'</document>';
+
+		// Implementation does not guarantee formatting so the test is somewhat fragile.
+		assert.strictEqual(xml, expected);
+	});
+
+	QUnit.test('UTC dates', function (assert) {
+		var date = new Date();
+		var js = {
+			'date': date
+		};
+		var x = new X2JS({
+			'jsDateUTC': true
+		});
+		var xml = x.js2xml(js);
+
+		var expected = '<date>' +
+			date.toUTCString() +
+			'</date>';
+
+		// Implementation does not guarantee formatting so the test is somewhat fragile.
+		assert.strictEqual(xml, expected);
+	});
+
+	QUnit.test('ISO dates', function (assert) {
+		var date = new Date();
+		var js = {
+			'date': date
+		};
+		var x = new X2JS();
+		var xml = x.js2xml(js);
+
+		var expected = '<date>' +
+			date.toISOString() +
+			'</date>';
+
+		// Implementation does not guarantee formatting so the test is somewhat fragile.
+		assert.strictEqual(xml, expected);
+	});
 });


### PR DESCRIPTION
Add parameter to convert dates to UTC instead of ISO (JS -> XML)
Add parameter to filter out elements based upon a function (JS -> XML)
Add parameter to convert elements before insertion (JS -> XML)

Bump the version to 3.1.2