### PR TITLE
deal with falsey __text values with attributes

### DIFF
--- a/tests_js2xml.js
+++ b/tests_js2xml.js
@@ -301,6 +301,45 @@
 		assert.strictEqual(xml, expected);
 	});
 
+        QUnit.test('Falsey element values + attributes', function (assert) {
+                var js = {
+                        'document': {
+                                'elementV': [
+                                        {
+                                                'm': {
+                                                        '__text': 'n',
+                                                        '_a': 'ns'
+                                                }
+                                        },
+                                        {
+                                                'm': {
+                                                        '__text': 0,
+                                                        '_a': 'ns'
+                                                }
+                                        },
+                                        {
+                                                'm': {
+                                                        '__text': false,
+                                                        '_a': 'ns'
+                                                }
+                                        }
+                                ]
+                        }
+                };
+                var x = new X2JS();
+                var xml = x.js2xml(js);
+
+                var expected = '<document>' +
+                        '<elementV><m a="ns">n</m></elementV>' +
+                        '<elementV><m a="ns">0</m></elementV>' +
+                        '<elementV><m a="ns">false</m></elementV>' +
+                        '</document>';
+
+                // Implementation does not guarantee formatting so the test is somewhat fragile.
+                assert.strictEqual(xml, expected);
+      });
+
+
 	QUnit.test('Namespaces', function (assert) {
 		var js = {
 			'document': {

--- a/x2js.js
+++ b/x2js.js
@@ -528,7 +528,7 @@
 				result += "<![CDATA[" + textNode.__cdata + "]]>";
 			}
 
-			if (textNode.__text) {
+			if (textNode.__text || typeof(textNode.__text) == 'number' || typeof(textNode.__text) == 'boolean' ) {
 				if (config.escapeMode)
 					result += escapeXmlChars(textNode.__text);
 				else
@@ -590,7 +590,7 @@
 					result += serializeEndTag(element, elementName);
 				} else {
 					var childElementCount = getDataElementCount(element);
-					if (childElementCount > 0 || element.__text || element.__cdata) {
+					if (childElementCount > 0 || typeof(element.__text) == 'number' || typeof(element.__text) == 'boolean' || element.__text || element.__cdata) {
 						result += serializeStartTag(element, elementName, attributes, false);
 						result += serializeJavaScriptObjectChildren(element);
 						result += serializeEndTag(element, elementName);


### PR DESCRIPTION
A JSON object with `_`-prefixed attributes and a `__text` value is converted into an XML element with attributes and the  `__text` value as its content. But if the  `__text` value is falsey and not a string (i.e. the number 0 or the boolean false), it is omitted from the XML: the test for an empty element incorrectly treats `0` and `false` the same as an empty string. This is fixed here for number and boolean.

As a result, the JSON

````
{ 'document': { 'elementV': [
  { 'm': {  '__text': 'n',  '_a': 'ns' } },
  { 'm': {  '__text': 0,  '_a': 'ns' } },
  { 'm': {  '__text': false, '_a': 'ns'  }  }
 ] } }
````

correctly maps to the XML

````
<document> 
  <elementV><m a="ns">n</m></elementV>
  <elementV><m a="ns">0</m></elementV>
  <elementV><m a="ns">false</m></elementV>
</document>
````

as opposed to its incorrect current behaviour:

````
<document> 
  <elementV><m a="ns">n</m></elementV>
  <elementV><m a="ns" /></elementV>
  <elementV><m a="ns" /></elementV>
</document>
````
