### PR TITLE
Fix incorrect version number

### DIFF
--- a/x2js.js
+++ b/x2js.js
@@ -48,7 +48,7 @@
 
 	// We return a constructor that can be used to make X2JS instances.
 	return function X2JS(config) {
-		var VERSION = "3.1.1";
+		var VERSION = "3.3.1";
 
 		config = config || {};
 


### PR DESCRIPTION
The latest version is `3.3.1` as stated in the `package.json`, whereas the JS file is showing an older version