### PR TITLE
Fix Angular/TS error TS2345 on dom2js method.

### DIFF
--- a/x2js.d.ts
+++ b/x2js.d.ts
@@ -65,7 +65,7 @@ declare class X2JS {
      * 
      * @memberOf X2JS
      */
-    dom2js<T>(domNode: Document): T;
+    dom2js<T>(domNode: Document | Node): T;
 
     /**
      * 


### PR DESCRIPTION
This fixes an Angular/TS error which occurs when trying to pass a Node element to the dom2js method.

Error description: 
TS2345: Argument of type 'Node' is not assignable to parameter of type 'Document'.